### PR TITLE
Changed Chart version number to 0.3.0

### DIFF
--- a/moodle/moodle-operator-chart/Chart.yaml
+++ b/moodle/moodle-operator-chart/Chart.yaml
@@ -4,4 +4,4 @@ sources:
 - https://github.com/cloud-ark/kubeplus-operators/releases/tag/v1
 description: A Helm chart for Moodle Operator 
 name: moodle-operator-chart
-version: 0.2.4
+version: 0.3.0


### PR DESCRIPTION
- Most recent helm package is 0.3.0
- PVCVolumeName field for moodle CRD. It is optional and used for Stash recoveries