### PR TITLE
Updated wiris plugin link

### DIFF
--- a/moodle/moodle-operator-chart/Chart.yaml
+++ b/moodle/moodle-operator-chart/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 appVersion: "1.0"
 sources:
-- https://github.com/cloud-ark/kubeplus-operators/releases/tag/v1
+- https://github.com/cloud-ark/kubeplus-operators/tree/master/moodle tag: 0.4.8
 description: A Helm chart for Moodle Operator 
 name: moodle-operator-chart
-version: 0.4.7
+version: 0.4.8
+

--- a/moodle/moodle-operator-chart/templates/deployment.yaml
+++ b/moodle/moodle-operator-chart/templates/deployment.yaml
@@ -48,12 +48,12 @@ spec:
     spec:
       containers:
       - name: moodle-operator
-        image: lmecld/moodle-operator:0.4.7
+        image: lmecld/moodle-operator:0.4.8
         imagePullPolicy: Always
         command: [ "/moodle"]
-        env:
-        - name: HOST_IP
-          value: {{ .Values.HOST_IP }}
+        #env:
+        #- name: HOST_IP
+        #  value: {{ .Values.HOST_IP }}
         #env:
         #- name: HOST_IP
         #  valueFrom:

--- a/moodle/pkg/utils/constants/constants.go
+++ b/moodle/pkg/utils/constants/constants.go
@@ -14,7 +14,7 @@ var PLUGIN_MAP = map[string]map[string]string{
 		"installFolder": "/var/www/html/local/",
 	},
 	"wiris": {
-		"downloadLink":  "https://moodle.org/plugins/download.php/18916/filter_wiris_moodle36_2019020700.zip",
+		"downloadLink":  "https://moodle.org/plugins/download.php/19765/filter_wiris_moodle37_2019061200.zip",
 		"installFolder": "/var/www/html/filter/",
 	},
 }


### PR DESCRIPTION
Also updated Ingress and Service object creation
to accommodate for when the Operator is being run
on Minikube.

Essentially when using on Minikube DomainName is not
needed to be specified in the Moodle Spec.
In this case the Ingress object does not need to have
TLS fields.
Similarly, making the Service object of type NodePort
instead of ClusterIP

Tagging a new release: 0.4.8